### PR TITLE
update to v0.1.6

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -55,7 +55,7 @@ if(LIBWALLY_TARGET_VERSION)
 set(LIBWALLY_TARGET_TAG  ${LIBWALLY_TARGET_VERSION})
 message(STATUS "[external project local] libwally-core target=${LIBWALLY_TARGET_VERSION}")
 else()
-set(LIBWALLY_TARGET_TAG  refs/tags/cfd-0.0.4)
+set(LIBWALLY_TARGET_TAG  refs/tags/cfd-0.0.6)
 endif()
 
 if(${USE_GIT_SSH})

--- a/src/cfdcore_elements_transaction.cpp
+++ b/src/cfdcore_elements_transaction.cpp
@@ -125,6 +125,22 @@ static ByteData CalculateRangeProof(
       (script_item[0].GetOpCode() == ScriptOperator::OP_RETURN) ||
       (script_byte.size() > Script::kMaxScriptSize)) {
     min_range_value = 0;
+  } else if (value == 0) {
+    warn(
+        CFD_LOG_SOURCE,
+        "Amount is 0. Cannot specify 0 for amount "
+        "if there is a valid confidential address.");  // NOLINT
+    throw CfdException(
+        kCfdIllegalArgumentError,
+        "Amount is 0. Cannot specify 0 for amount "
+        "if there is a valid confidential address.");  // NOLINT
+  }
+
+  if (value < static_cast<uint64_t>(min_range_value)) {
+    warn(CFD_LOG_SOURCE, "amount less than minimumRangeValue");
+    throw CfdException(
+        kCfdIllegalArgumentError,
+        "The amount is less than the minimumRangeValue.");
   }
 
   if (pubkey == nullptr) {

--- a/src/cfdcore_hdwallet.cpp
+++ b/src/cfdcore_hdwallet.cpp
@@ -188,12 +188,17 @@ static std::vector<uint32_t> ToArrayFromString(
       continue;  // master key
     }
     if (str.empty()) {
-      warn(
-          CFD_LOG_SOURCE, "{} bip32 string path fail. empty item.",
-          caller_name);
-      throw CfdException(
-          CfdError::kCfdIllegalArgumentError,
-          caller_name + " bip32 string path fail. empty item.");
+      if (index == 0) {
+        // start slash pattern
+        continue;
+      } else {
+        warn(
+            CFD_LOG_SOURCE, "{} bip32 string path fail. empty item.",
+            caller_name);
+        throw CfdException(
+            CfdError::kCfdIllegalArgumentError,
+            caller_name + " bip32 string path fail. empty item.");
+      }
     }
 
     // strtol関数による変換

--- a/test/test_extpubkey.cpp
+++ b/test/test_extpubkey.cpp
@@ -160,6 +160,10 @@ TEST(ExtPubkey, DerivePubkeyTest) {
   EXPECT_STREQ(child2.GetPubkey().GetHex().c_str(), child.GetPubkey().GetHex().c_str());
 
   EXPECT_THROW((child2 = extkey.DerivePubkey("m/1/1")), CfdException);  // master 
+
+  EXPECT_NO_THROW((child2 = extkey.DerivePubkey("/1/1")));  // start slash
+
+  EXPECT_THROW((child2 = extkey.DerivePubkey("1/2//3")), CfdException);  // empty number
 }
 
 TEST(ExtPubkey, DerivePubTweakTest) {


### PR DESCRIPTION
## Linked Issue

<!--
for linked ZenHub Issue or other repository issue.
  - ZenHub's issue URL
  - other repository's issue URL
-->

## Overview

- update from cryptogarageinc v0.1.17
  - fix: enable bip32path starting with slash
  - feat: check minimum range value.
  - fix: update range proof check.
  - upgrade: update libwally-core to cfd-v0.0.6

## How to use

<!-- 
- How to check the operation
  - For tasks that require operation confirmation, enter the required commands, etc.
  - If not needed, leave blank
-->

```bash
```

## Items reserved this time, or TODO

<!--
- If not needed, leave blank
-->

## Check list

** Person who issued **
- [ ] checked script <!-- npm run check -->
- [ ] build successed
- [ ] Linked PullRequest and Issue

** Reviewer **
- [ ] (if necessary) Record the review results of related tickets.

## Memo

<!--
- Explain any considerations or considerations.
-->
